### PR TITLE
Fix common prefix filter -- warnings are now shown

### DIFF
--- a/src/components/GrammarAnalysis.vue
+++ b/src/components/GrammarAnalysis.vue
@@ -128,7 +128,7 @@ export default {
         return false
       }
 
-      if (this.filterCommonPrefix && !nonTerminal.commonPrefixes.exist) {
+      if (this.filterCommonPrefix && !nonTerminal.commonPrefixes.exist && nonTerminal.commonPrefixes.warnings.length === 0) {
         return false
       }
 


### PR DESCRIPTION
As in title - common prefix warnings are now shown when you filter for 'Common Prefix'